### PR TITLE
feat: bootstrap and graceful shutdown

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,92 +11,92 @@ linters-settings:
       - (net/http.ResponseWriter).Write
 
   gocognit:
-    min-complexity: 8
+    min-complexity: 15
 
   gocritic:
     enabled-checks:
-      - appendassign
-      - appendcombine
-      - argorder
-      - assignop
-      - badcall
-      - badcond
-      - badlock
-      - badregexp
-      - boolexprsimplify
-      - builtinshadow
-      - builtinshadowdecl
-      - captlocal
-      - caseorder
-      - codegencomment
-      - commentedoutcode
-      - commentedoutimport
-      - commentformatting
-      - defaultcaseorder
-      - deferunlambda
-      - deprecatedcomment
-      - docstub
-      - duparg
-      - dupbranchbody
-      - dupcase
-      - dupimport
-      - dupsubexpr
+      - appendAssign
+      - appendCombine
+      - argOrder
+      - assignOp
+      - badCall
+      - badCond
+      - badLock
+      - badRegexp
+      - boolExprSimplify
+      - builtinShadow
+      - builtinShadowDecl
+      - captLocal
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - commentedOutImport
+      - commentFormatting
+      - defaultCaseOrder
+      - deferUnlambda
+      - deprecatedComment
+      - docStub
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupImport
+      - dupSubExpr
       - elseif
-      - emptyfallthrough
-      - emptystringtest
-      - equalfold
-      - evalorder
-      - exitafterdefer
-      - filepathjoin
-      - flagderef
-      - flagname
-      - hexliteral
-      - hugeparam
-      - ifelsechain
-      - importshadow
-      - indexalloc
-      - initclause
-      - mapkey
-      - methodexprcall
-      - nestingreduce
-      - newderef
-      - nilvalreturn
-      - octalliteral
-      - offby1
-      - paramtypecombine
-      - ptrtorefparam
-      - rangeexprcopy
-      - rangevalcopy
-      - regexpmust
-      - regexppattern
-      - regexpsimplify
+      - emptyFallthrough
+      - emptyStringTest
+      - equalFold
+      - evalOrder
+      - exitAfterDefer
+      - filepathJoin
+      - flagDeref
+      - flagName
+      - hexLiteral
+      - hugeParam
+      - ifElseChain
+      - importShadow
+      - indexAlloc
+      - initClause
+      - mapKey
+      - methodExprCall
+      - nestingReduce
+      - newDeref
+      - nilValReturn
+      - octalLiteral
+      - offBy1
+      - paramTypeCombine
+      - ptrToRefParam
+      - rangeExprCopy
+      - rangeValCopy
+      - regexpMust
+      - regexpPattern
+      - regexpSimplify
       - ruleguard
-      - singlecaseswitch
-      - sloppylen
-      - sloppyreassign
-      - sloppytypeassert
-      - sortslice
-      - sqlquery
-      - stringxbytes
-      - switchtrue
-      - toomanyresultschecker
-      - truncatecmp
-      - typeassertchain
-      - typedeffirst
-      - typeswitchvar
-      - typeunparen
+      - singleCaseSwitch
+      - sloppyLen
+      - sloppyReassign
+      - sloppyTypeAssert
+      - sortSlice
+      - sqlQuery
+      - stringXbytes
+      - switchTrue
+      - tooManyResultsChecker
+      - truncateCmp
+      - typeAssertChain
+      - typeDefFirst
+      - typeSwitchVar
+      - typeUnparen
       - underef
-      # - unamedresult
-      - unlabelstmt
+      # - unamedResult
+      - unlabelStmt
       - unlambda
-      - unnecessaryblock
-      - unnecessarydefer
+      - unnecessaryBlock
+      - unnecessaryDefer
       - unslice
-      - valswap
-      - weakcond
+      - valSwap
+      - weakCond
       # - whynolint
-      - wrapperfunc
-      - yodastyleexpr
+      - wrapperFunc
+      - yodaStyleExpr
 
     settings:
       hugeParam:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,7 +47,7 @@ func main() {
 // If the bootstrap of the server fails, run returns a non-nil error.
 // Otherwise the caller must use the shutdown.Handle to stop the server.
 func run(ctx context.Context, cancel context.CancelFunc) (*shutdown.Handle, error) {
-	configPath := flag.String("config", defaultConfigPath, "")
+	configPath := flag.String("config", defaultConfigPath, "Path to the configuration file (for example --config .env)")
 
 	flag.Parse()
 

--- a/shutdown/handle.go
+++ b/shutdown/handle.go
@@ -1,0 +1,22 @@
+package shutdown
+
+// Handle is a configurable shutdown handle that executes a
+// custom shutdown procedure.
+type Handle struct {
+	handleFunc func() error
+}
+
+func NewHandle(f func() error) *Handle {
+	return &Handle{
+		handleFunc: f,
+	}
+}
+
+// Call calls the registered handlFunc on Handle.
+// Invoking Call is noop if handlFunc is nil.
+func (h *Handle) Call() error {
+	if h.handleFunc == nil {
+		return nil
+	}
+	return h.handleFunc()
+}

--- a/shutdown/signal.go
+++ b/shutdown/signal.go
@@ -1,0 +1,17 @@
+package shutdown
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// ListenInterrupt listens for OS interrupt signals and calls f on receive.
+// Calling ListenInterrupt blocks until a signal is received and thus must
+// called inside a goroutine separated from the main program.
+func ListenInterrupt(f func()) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+	f()
+}


### PR DESCRIPTION
## Description

Breaks `main` in many methods for a more granular configuration. Offers:

- configurable graceful shutdown procedure with `shutdown` package.
- `config` struct defining the program variable configuration (à la 12 factors app), config is read from file with default being `.env`. Accepts one single flag: `config` to provide the path to the config file.

## Changes

Refactor `cmd/main`.

Update `golangci-yml`:
- use camelCase check names (for yaml reference intellisense)
- increase min cognitive complexity report from 8 to 15 (recommended is between 10 and 20, so right in the middle)

## Notes

Coses #14 