### PR TITLE
feat: limit request body bytes read

### DIFF
--- a/server.go
+++ b/server.go
@@ -47,3 +47,12 @@ func (s *Server) init() {
 func (s *Server) localAddr() string {
 	return fmt.Sprintf("http://localhost%s", s.Addr)
 }
+
+func LimitBytesReader(size int64) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, size)
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -11,6 +11,8 @@ import (
 	"github.com/benchttp/server/httplog"
 )
 
+const maxBytesRead = 1 << 20 // 1 MiB
+
 type Server struct {
 	*http.Server
 	router *mux.Router
@@ -38,6 +40,7 @@ func (s *Server) init() {
 	s.router = mux.NewRouter().StrictSlash(true)
 
 	s.router.Use(httplog.Request)
+	s.router.Use(LimitBytesReader(maxBytesRead))
 
 	s.registerRoutes()
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,77 @@
+package server_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/benchttp/server"
+)
+
+func TestLimitBytesReader(t *testing.T) {
+	testcases := []struct {
+		label   string
+		maxSize int64
+		body    []byte
+		expSize int
+		expErr  string
+	}{
+		{
+			label:   "do not limit body below max size",
+			body:    []byte("a"),
+			maxSize: 3,
+			expSize: 1,
+			expErr:  "",
+		},
+		{
+			label:   "do not limit body equal to max size",
+			body:    []byte("abc"),
+			maxSize: 3,
+			expSize: 3,
+			expErr:  "",
+		},
+		{
+			label:   "limit body above max size",
+			body:    []byte("abcdef"),
+			maxSize: 3,
+			expSize: 3,
+			expErr:  "http: request body too large",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			rq := httptest.NewRequest("", "/", ioReader(tc.body))
+
+			var (
+				gotSize int
+				gotErr  string
+			)
+
+			server.LimitBytesReader(tc.maxSize)(
+				http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+					b, err := io.ReadAll(r.Body)
+					if err != nil {
+						gotErr = err.Error()
+					}
+					gotSize = len(b)
+				}),
+			).ServeHTTP(rr, rq)
+
+			if gotSize != tc.expSize {
+				t.Errorf("body size: exp %d, got %d", tc.expSize, gotSize)
+			}
+
+			if gotErr != tc.expErr {
+				t.Errorf("read error: exp %q, got %q", tc.expErr, gotErr)
+			}
+		})
+	}
+}
+
+func ioReader(b []byte) io.Reader {
+	return bytes.NewReader(b)
+}


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

Limit the request body size to be read.
Limit is set to `1MiB`.
It is done using a global middleware so it affects all incoming requests.

<!--
    Describe briefly what this PR does, if the issue description is not enough.
    Add any information that could be relevant for the reviewers.
-->

## Changes

<!-- Optional: mention here indirect changes impacted by the PR -->

## Notes

- closes #19 
- related to https://github.com/benchttp/runner/issues/62

<!-- Optional: additional notes than can help understanding the implementation -->
