### PR TITLE
Refactor/improve data layer structs and methods

### DIFF
--- a/benchttp/stats.go
+++ b/benchttp/stats.go
@@ -20,12 +20,12 @@ type Codestats struct {
 
 // Timestats represents the time stats related to a computed stats group
 type Timestats struct {
-	Min               float64   `json:"min"`
-	Max               float64   `json:"max"`
-	Mean              float64   `json:"mean"`
-	Median            float64   `json:"median"`
-	StandardDeviation float64   `json:"standardDeviation"`
-	Deciles           []float64 `json:"deciles"`
+	Min     float64   `json:"min"`
+	Max     float64   `json:"max"`
+	Mean    float64   `json:"mean"`
+	Median  float64   `json:"median"`
+	StdDev  float64   `json:"standardDeviation"`
+	Deciles []float64 `json:"deciles"`
 }
 
 // Stats contains StatsDescriptor, Codestats and Timestats of a given computed stats group

--- a/benchttp/stats.go
+++ b/benchttp/stats.go
@@ -18,19 +18,19 @@ type Codestats struct {
 	Code5xx int `json:"code5xx"`
 }
 
-// Stats represents the time stats related to a computed stats group
+// Timestats represents the time stats related to a computed stats group
 type Timestats struct {
-	Min      float64   `json:"min"`
-	Max      float64   `json:"max"`
-	Mean     float64   `json:"mean"`
-	Median   float64   `json:"median"`
-	Variance float64   `json:"average"`
-	Deciles  []float64 `json:"deciles"`
+	Min               float64   `json:"min"`
+	Max               float64   `json:"max"`
+	Mean              float64   `json:"mean"`
+	Median            float64   `json:"median"`
+	StandardDeviation float64   `json:"standardDeviation"`
+	Deciles           []float64 `json:"deciles"`
 }
 
-// Stats contains StatsDescriptor, Codestats and Stats of a given computed stats group
+// Stats contains StatsDescriptor, Codestats and Timestats of a given computed stats group
 type Stats struct {
-	StatsDescriptor `json:"statsDescriptor"`
-	Codestats       `json:"codestats"`
-	Timestats       `json:"timestats"`
+	Descriptor StatsDescriptor `json:"descriptor"`
+	Code       Codestats       `json:"code"`
+	Time       Timestats       `json:"time"`
 }

--- a/routes.go
+++ b/routes.go
@@ -42,9 +42,9 @@ func (s *Server) registerRoutes() {
 
 	v1.HandleFunc("/reports/"+idPathVar, s.retrieveReport).Methods("GET")
 
-	v1.HandleFunc("/stats", s.ListAvailable).Methods("GET")
+	v1.HandleFunc("/stats", s.retrieveAllStats).Methods("GET")
 
-	v1.HandleFunc("/stats/"+idPathVar, s.GetByID).Methods("GET")
+	v1.HandleFunc("/stats/"+idPathVar, s.retrieveStatsByID).Methods("GET")
 }
 
 func handleRoot(rw http.ResponseWriter, _ *http.Request) {

--- a/services/postgresql/stats.go
+++ b/services/postgresql/stats.go
@@ -76,7 +76,7 @@ ORDER BY s.finished_at DESC`[1:]
 		&stats.Time.Max,
 		&stats.Time.Mean,
 		&stats.Time.Median,
-		&stats.Time.StandardDeviation,
+		&stats.Time.StdDev,
 		(*pq.Float64Array)(&stats.Time.Deciles),
 	)
 	if err != nil {

--- a/services/postgresql/stats.go
+++ b/services/postgresql/stats.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s StatsService) ListAvailable(userID string) ([]benchttp.StatsDescriptor, error) {
-	statsDescriptorsList := []benchttp.StatsDescriptor{}
+	list := []benchttp.StatsDescriptor{}
 
 	stmt, err := s.db.Prepare(`SELECT id, tag, finished_at FROM stats_descriptor WHERE user_id = $1 ORDER BY finished_at DESC`)
 	if err != nil {
@@ -31,10 +31,10 @@ func (s StatsService) ListAvailable(userID string) ([]benchttp.StatsDescriptor, 
 		if err != nil {
 			return nil, err
 		}
-		statsDescriptorsList = append(statsDescriptorsList, statsDescriptor)
+		list = append(list, statsDescriptor)
 	}
 
-	return statsDescriptorsList, nil
+	return list, nil
 }
 
 func (s StatsService) GetByID(statsDescriptorID string) (benchttp.Stats, error) {

--- a/services/postgresql/stats.go
+++ b/services/postgresql/stats.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s StatsService) ListAvailable(userID string) ([]benchttp.StatsDescriptor, error) {
-	statsDescriptorList := []benchttp.StatsDescriptor{}
+	statsDescriptorsList := []benchttp.StatsDescriptor{}
 
 	stmt, err := s.db.Prepare(`SELECT id, tag, finished_at FROM stats_descriptor WHERE user_id = $1 ORDER BY finished_at DESC`)
 	if err != nil {
@@ -31,10 +31,10 @@ func (s StatsService) ListAvailable(userID string) ([]benchttp.StatsDescriptor, 
 		if err != nil {
 			return nil, err
 		}
-		statsDescriptorList = append(statsDescriptorList, statsDescriptor)
+		statsDescriptorsList = append(statsDescriptorsList, statsDescriptor)
 	}
 
-	return statsDescriptorList, nil
+	return statsDescriptorsList, nil
 }
 
 func (s StatsService) GetByID(statsDescriptorID string) (benchttp.Stats, error) {
@@ -64,20 +64,20 @@ ORDER BY s.finished_at DESC`[1:]
 
 	row := s.db.QueryRow(stmt, statsDescriptorID)
 	err := row.Scan(
-		&stats.StatsDescriptor.ID,
-		&stats.StatsDescriptor.Tag,
-		&stats.StatsDescriptor.FinishedAt,
-		&stats.Codestats.Code1xx,
-		&stats.Codestats.Code2xx,
-		&stats.Codestats.Code3xx,
-		&stats.Codestats.Code4xx,
-		&stats.Codestats.Code5xx,
-		&stats.Timestats.Min,
-		&stats.Timestats.Max,
-		&stats.Timestats.Mean,
-		&stats.Timestats.Median,
-		&stats.Timestats.Variance,
-		(*pq.Float64Array)(&stats.Timestats.Deciles),
+		&stats.Descriptor.ID,
+		&stats.Descriptor.Tag,
+		&stats.Descriptor.FinishedAt,
+		&stats.Code.Code1xx,
+		&stats.Code.Code2xx,
+		&stats.Code.Code3xx,
+		&stats.Code.Code4xx,
+		&stats.Code.Code5xx,
+		&stats.Time.Min,
+		&stats.Time.Max,
+		&stats.Time.Mean,
+		&stats.Time.Median,
+		&stats.Time.StandardDeviation,
+		(*pq.Float64Array)(&stats.Time.Deciles),
 	)
 	if err != nil {
 		return stats, ErrScanningRows

--- a/stats.go
+++ b/stats.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListAvailable(w http.ResponseWriter, r *http.Request) {
+func (s *Server) retrieveAllStats(w http.ResponseWriter, r *http.Request) {
 	// TO DO: get userID from authentication to use it here instead of "1"
 	stats, err := s.StatsService.ListAvailable("1")
 	if err != nil {
@@ -15,7 +15,7 @@ func (s *Server) ListAvailable(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, stats, 200)
 }
 
-func (s *Server) GetByID(w http.ResponseWriter, r *http.Request) {
+func (s *Server) retrieveStatsByID(w http.ResponseWriter, r *http.Request) {
 	id, err := pathParam(r, idParam)
 	if err != nil {
 		writeError(w, ErrBadRequest.Wrap(err))


### PR DESCRIPTION
## Description

Some refactor in the data layer structs and methods after PR #18 , mainly to names.

## Changes

- make handlers from the server package non-exported
- rename the server handler methods:
```
    v1.HandleFunc("/stats", s.retrieveAllStats).Methods("GET")
    v1.HandleFunc("/stats/"+idPathVar, s.retrieveStatsByID).Methods("GET")
```

- change Variance to StandardDeviation
- rename Stats struct fields

- add omitempty to all the Codestats fields? -> I decided to not add it, we will have 0 if there are no Codestats.

## Notes
/