### PR TITLE
Remove `tag`, fix `standard_deviation` in sql query

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,10 @@ Status: 200 OK
 [
   {
     "id": "lwkaFmtuCoeKSFhbndTC",
-    "tag": "my-custom-tag",
     "finishedAt": "2022-02-27T19:54:19.019717Z"
   },
   {
     "id": "XbqWESZWGC9iaXSWPDmu",
-    "tag": "my-other-custom-tag",
     "finishedAt": "2022-03-03T18:00:19.019717Z"
   }
 ]
@@ -167,7 +165,6 @@ Status: 200 OK
 {
   "descriptor": {
     "id": "lwkaFmtuCoeKSFhbndTC",
-    "tag": "my-custom-tag",
     "finishedAt": "2022-02-27T19:54:19.019717Z"
   },
   "time": {

--- a/benchttp/stats.go
+++ b/benchttp/stats.go
@@ -5,7 +5,6 @@ import "time"
 // StatsDescriptor contains a computed stats group description information
 type StatsDescriptor struct {
 	ID         string    `json:"id"`
-	Tag        string    `json:"tag"`
 	FinishedAt time.Time `json:"finishedAt"`
 }
 

--- a/services/postgresql/stats.go
+++ b/services/postgresql/stats.go
@@ -9,7 +9,7 @@ import (
 func (s StatsService) ListAvailable(userID string) ([]benchttp.StatsDescriptor, error) {
 	list := []benchttp.StatsDescriptor{}
 
-	stmt, err := s.db.Prepare(`SELECT id, tag, finished_at FROM stats_descriptor WHERE user_id = $1 ORDER BY finished_at DESC`)
+	stmt, err := s.db.Prepare(`SELECT id, finished_at FROM stats_descriptor WHERE user_id = $1 ORDER BY finished_at DESC`)
 	if err != nil {
 		return []benchttp.StatsDescriptor{}, ErrPreparingStmt
 	}
@@ -25,7 +25,6 @@ func (s StatsService) ListAvailable(userID string) ([]benchttp.StatsDescriptor, 
 		statsDescriptor := benchttp.StatsDescriptor{}
 		err = rows.Scan(
 			&statsDescriptor.ID,
-			&statsDescriptor.Tag,
 			&statsDescriptor.FinishedAt,
 		)
 		if err != nil {
@@ -43,7 +42,6 @@ func (s StatsService) GetByID(statsDescriptorID string) (benchttp.Stats, error) 
 	stmt := `
 SELECT
 	s.id,
-	s.tag,
 	s.finished_at,
 	c.code_1xx,
 	c.code_2xx,
@@ -54,7 +52,7 @@ SELECT
 	t.max,
 	t.mean,
 	t.median,
-	t.variance,
+	t.standard_deviation,
 	t.deciles
 FROM public.stats_descriptor AS s
 INNER JOIN public.codestats AS c ON c.stats_descriptor_id = s.id
@@ -65,7 +63,6 @@ ORDER BY s.finished_at DESC`[1:]
 	row := s.db.QueryRow(stmt, statsDescriptorID)
 	err := row.Scan(
 		&stats.Descriptor.ID,
-		&stats.Descriptor.Tag,
 		&stats.Descriptor.FinishedAt,
 		&stats.Code.Code1xx,
 		&stats.Code.Code2xx,


### PR DESCRIPTION
## Description
/

## Changes
Remove `tag` field since we do not use it at the moment.
Correct `variation` to `standard_deviation` in SQL query.

## Notes
/
